### PR TITLE
Pics links

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -1,7 +1,7 @@
 [linuxserverurl]: https://linuxserver.io
 [![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
 
-## This is a Container in active development by the [![LinuxServer.io][linuxserverurl] team and is not recommended for use by the general public.
+## This is a Container in active development by the [![LinuxServer.io[linuxserverurl] team and is not recommended for use by the general public.
 
 If you want to comment\contribute on this container , are looking for support on any of our other work , or are curious about us in general, check out the following.
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,3 @@
-[linuxserverurl]: https://linuxserver.io
 [![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
 
 ## This is a Container in active development by the [LinuxServer.io][linuxserverurl] team and is not recommended for use by the general public.
@@ -8,4 +7,6 @@ If you want to comment\contribute on this container , are looking for support on
 * [forum.linuxserver.io](https://forum.linuxserver.io)
 * [IRC](https://www.linuxserver.io/index.php/irc/) on freenode at `#linuxserver.io`
 * [Podcast](https://www.linuxserver.io/index.php/category/podcast/) covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
+
+[linuxserverurl]: https://linuxserver.io
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,12 +1,15 @@
+[linuxserverurl]: https://linuxserver.io
+[forumurl]: https://forum.linuxserver.io
+[ircurl]: https://www.linuxserver.io/index.php/irc/
+[podcasturl]: https://www.linuxserver.io/index.php/category/podcast/
+
 [![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
 
 ## This is a Container in active development by the [LinuxServer.io][linuxserverurl] team and is not recommended for use by the general public.
 
 If you want to comment\contribute on this container , are looking for support on any of our other work , or are curious about us in general, check out the following.
 
-* [forum.linuxserver.io](https://forum.linuxserver.io)
-* [IRC](https://www.linuxserver.io/index.php/irc/) on freenode at `#linuxserver.io`
-* [Podcast](https://www.linuxserver.io/index.php/category/podcast/) covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
-
-[linuxserverurl]: https://linuxserver.io
+* [forum.linuxserver.io][forumurl]
+* [IRC][ircurl] on freenode at `#linuxserver.io`
+* [Podcast][podcasturl] covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,3 +1,4 @@
+[linuxserverurl]: https://linuxserver.io
 [![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
 
 ## This is a Container in active development by the [![LinuxServer.io][linuxserverurl] team and is not recommended for use by the general public.

--- a/template/README.md
+++ b/template/README.md
@@ -1,6 +1,6 @@
-![https://linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)
+[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
 
-## This is a Container in active development by the [LinuxServer.io](https://linuxserver.io) team and is not recommended for use by the general public.
+## This is a Container in active development by the [![LinuxServer.io][linuxserverurl] team and is not recommended for use by the general public.
 
 If you want to comment\contribute on this container , are looking for support on any of our other work , or are curious about us in general, check out the following.
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,7 +1,7 @@
 [linuxserverurl]: https://linuxserver.io
 [![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
 
-## This is a Container in active development by the [![LinuxServer.io[linuxserverurl] team and is not recommended for use by the general public.
+## This is a Container in active development by the [LinuxServer.io][linuxserverurl] team and is not recommended for use by the general public.
 
 If you want to comment\contribute on this container , are looking for support on any of our other work , or are curious about us in general, check out the following.
 

--- a/template/READMETEMPLATE.md
+++ b/template/READMETEMPLATE.md
@@ -1,9 +1,14 @@
-![https://linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)
+[linuxserverurl]: https://linuxserver.io
+[forumurl]: https://forum.linuxserver.io
+[ircurl]: https://www.linuxserver.io/index.php/irc/
+[podcasturl]: https://www.linuxserver.io/index.php/category/podcast/
 
-The [LinuxServer.io](https://linuxserver.io) team brings you another container release featuring auto-update on startup, easy user mapping and community support. Find us for support at:
-* [forum.linuxserver.io](https://forum.linuxserver.io)
-* [IRC](https://www.linuxserver.io/index.php/irc/) on freenode at `#linuxserver.io`
-* [Podcast](https://www.linuxserver.io/index.php/category/podcast/) covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
+[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)][linuxserverurl]
+
+The [LinuxServer.io][linuxserverurl] team brings you another container release featuring easy user mapping and community support. Find us for support at:
+* [forum.linuxserver.io][forumurl]
+* [IRC][ircurl] on freenode at `#linuxserver.io`
+* [Podcast][podcasturl] covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
 
 # linuxserver/<container-name>
 


### PR DESCRIPTION
Stress it's not a rewrite !!!!!

Just making the linuxserver banner a clickable link to our site, taking out the autoupdate line from the initial blurb on the READMETEMPLATE.md file and using the form

[Linuxserver.io][linuxserverurl]

for any links, defining [linuxserverurl] etc... at the top of README.md and READMETEMPLATE.md.

Thought it may be easier if any rewrites were using multiple instances of any links, would only have to change the relevant link once if we move etc.... as well as making it more shorthand.
